### PR TITLE
fix text is not displayed clearly when in dark mode

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -33,7 +33,7 @@ export default function Header(props) {
                 </Box>
             </Center>
             <Center>
-                <Text textAlign="center" color="gray.600">
+                <Text textAlign="center">
                     Kumpulan jokes lucu yang tersedia dalam bahasa Indonesia. Project ini
                     dibuat untuk memeriahkan #hacktoberfest2021
                 </Text>


### PR DESCRIPTION
fix text is not displayed clearly when in dark mode, because the color is statically defined, not from dynamic css (dark/light)