### PR TITLE
fix Divider not visible in Light theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,8 +19,8 @@ export default function App() {
           <Header isLightMode={isLightMode} toggleTheme={onChangeTheme} />
         }
       />
-      <LazyLoad children={<Home />} />
-      <LazyLoad children={<Footer />} />
+      <LazyLoad children={<Home isLightMode={isLightMode} />} />
+      <LazyLoad children={<Footer isLightMode={isLightMode} />} />
     </ChakraProvider>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,10 +2,10 @@ import { Stack, Divider, Center, Text } from "@chakra-ui/react";
 
 const year = new Date().getFullYear();
 
-export default function Footer() {
+export default function Footer(props) {
   return (
     <Stack marginTop="20" marginBottom="10">
-      <Divider />
+      <Divider borderColor={props.isLightMode ? "black" : "white"} />
       <Center>
         <Text fontSize="sm">Copyright &copy; {year}</Text>
       </Center>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -4,10 +4,10 @@ import jokes from "../assets/jokes.json";
 
 const data = jokes.data;
 
-export default function Home() {
+export default function Home(props) {
   return (
     <Container maxW="container.xl" centerContent>
-      <Divider orientation="horizontal" colorScheme="blue" marginBottom="10" />
+      <Divider orientation="horizontal" borderColor={props.isLightMode ? "black" : "white"} marginBottom="10" />
       <List data={data} />
     </Container>
   );


### PR DESCRIPTION
tips for improvement : maybe can use extendTheme method globally to avoid using "isLightMode" props repeatedly